### PR TITLE
fail when base dir not exists

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -20,8 +20,12 @@ info "using github repo \"$repo\""
 remote="https://$WERCKER_GH_PAGES_TOKEN@github.com/$repo.git"
 
 # if directory provided, cd to it
-if [ -d "$WERCKER_GH_PAGES_BASEDIR" ]; then
-  cd "$WERCKER_GH_PAGES_BASEDIR"
+if [ -n "$WERCKER_GH_PAGES_BASEDIR" ]; then
+  if [ -d "$WERCKER_GH_PAGES_BASEDIR" ]; then
+    cd "$WERCKER_GH_PAGES_BASEDIR"
+  else
+    fail "\"basedir\" do not exist. was the build step performed?"
+  fi
 fi
 
 # remove existing commit history

--- a/wercker-step.yml
+++ b/wercker-step.yml
@@ -1,5 +1,5 @@
 name: gh-pages
-version: 0.2.1
+version: 0.2.2
 description: deploy to github pages
 keywords:
   - github


### PR DESCRIPTION
This prevents code to be pushed when the build site is on a subdirectory, and the basedir is declared
This could wipe the github pages